### PR TITLE
Suppression du modèle `test_field` dans le schéma Prisma et ajout de …

### DIFF
--- a/prisma/migrations/20250402174041_suppression_du_model_de_tests/migration.sql
+++ b/prisma/migrations/20250402174041_suppression_du_model_de_tests/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - You are about to drop the `test_field` table. If the table is not empty, all the data it contains will be lost.
+
+*/
+-- DropTable
+DROP TABLE "test_field";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -284,9 +284,3 @@ model user {
   community_qa_answers               community_qa_answers[]
   community_qa_questions             community_qa_questions[]
 }
-
-model test_field {
-  id Int @id @default(autoincrement())
-  test_field String? @default("test")
-  test_field2 String? @default("test2")
-}


### PR DESCRIPTION
…la migration SQL correspondante pour supprimer la table associée.